### PR TITLE
Fix german translation: Scheck -> Okay

### DIFF
--- a/src/js/configures/i18n.js
+++ b/src/js/configures/i18n.js
@@ -75,7 +75,7 @@ define([], () => {
         cancel: '取消'
       },
       de: {
-        ok: 'Scheck',
+        ok: 'Okay',
         cancel: 'Abbrechen'
       },
       jp: {


### PR DESCRIPTION
"Scheck" is not used in German for something like that